### PR TITLE
Fix clearRect coordinate mistake when reading GIF

### DIFF
--- a/src/AnimatedGIF.ts
+++ b/src/AnimatedGIF.ts
@@ -202,7 +202,7 @@ class AnimatedGIF extends Sprite
             context.drawImage(patchCanvas, left, top);
             const imageData = context.getImageData(0, 0, canvas.width, canvas.height);
 
-            if (disposalType === 2)
+            if (disposalType === 2 || disposalType === 3)
             {
                 context.clearRect(left, top, width, height);
             }

--- a/src/AnimatedGIF.ts
+++ b/src/AnimatedGIF.ts
@@ -204,7 +204,7 @@ class AnimatedGIF extends Sprite
 
             if (disposalType === 2)
             {
-                context.clearRect(0, 0, width, height);
+                context.clearRect(left, top, width, height);
             }
 
             frames.push({


### PR DESCRIPTION
In AnimatedGIF.ts

```javascript
            patchCanvas.width = width;
            patchCanvas.height = height;
            patchContext.clearRect(0, 0, width, height);
            const patchData = patchContext.createImageData(width, height);

            patchData.data.set(patch);
            patchContext.putImageData(patchData, 0, 0);

            // draw image at (left, top, width, height)
            context.drawImage(patchCanvas, left, top);
            const imageData = context.getImageData(0, 0, canvas.width, canvas.height);

            if (disposalType === 2)
            {
                // but clear rect at (0, 0, width, height)
                context.clearRect(0, 0, width, height);
            }
```

When the image has transparent pixels, `left` and `top` are not always 0, which can cause `clearRect` range errors, and results in issue like #3 